### PR TITLE
feat: build a grid of elements

### DIFF
--- a/app/src/main/java/com/example/grid/MainActivity.kt
+++ b/app/src/main/java/com/example/grid/MainActivity.kt
@@ -7,16 +7,17 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -51,25 +52,25 @@ class MainActivity : ComponentActivity() {
 fun GridApp(modifier: Modifier = Modifier) {
     val window = (LocalView.current.context as Activity).window
     window.statusBarColor = MaterialTheme.colorScheme.primary.toArgb()
-
-    LazyColumn(modifier = modifier.safeDrawingPadding()) {
-        items(Datasource.topics.chunked(2) + Datasource.topics.chunked(2)) {
-            Row {
-                GridAppItem(topic = it[0])
-                GridAppItem(topic = it[1])
-            }
+    
+    LazyVerticalGrid(
+        modifier = modifier.safeDrawingPadding(),
+        columns = GridCells.FixedSize(200.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        items(Datasource.topics + Datasource.topics) {
+            GridAppItem(topic = it)
         }
     }
 }
 
 @Composable
-fun RowScope.GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
+fun GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .padding(8.dp)
             .height(68.dp)
             .clip(shape = RoundedCornerShape(20.dp))
-            .weight(1f)
             .background(MaterialTheme.colorScheme.secondaryContainer)
     ) {
         Image(

--- a/app/src/main/java/com/example/grid/MainActivity.kt
+++ b/app/src/main/java/com/example/grid/MainActivity.kt
@@ -1,0 +1,114 @@
+package com.example.grid
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.grid.data.Datasource
+import com.example.grid.data.Topic
+import com.example.grid.ui.theme.GridTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            GridTheme {
+                GridApp()
+            }
+        }
+    }
+}
+
+@Composable
+fun GridApp(modifier: Modifier = Modifier) {
+    val window = (LocalView.current.context as Activity).window
+    window.statusBarColor = MaterialTheme.colorScheme.primary.toArgb()
+
+    LazyColumn(modifier = modifier.safeDrawingPadding()) {
+        items(Datasource.topics.chunked(2) + Datasource.topics.chunked(2)) {
+            Row {
+                GridAppItem(topic = it[0])
+                GridAppItem(topic = it[1])
+            }
+        }
+    }
+}
+
+@Composable
+fun RowScope.GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .padding(8.dp)
+            .height(68.dp)
+            .clip(shape = RoundedCornerShape(20.dp))
+            .weight(1f)
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+    ) {
+        Image(
+            modifier = modifier
+                .fillMaxHeight()
+                .width(68.dp),
+            painter = painterResource(topic.icon),
+            contentDescription = stringResource(topic.name)
+        )
+        Column(modifier = Modifier.padding(16.dp, 0.dp, 0.dp, 0.dp)) {
+            Text(
+                text = stringResource(topic.name),
+                modifier = modifier.padding(0.dp, 16.dp, 16.dp, 8.dp),
+                color = Color(0xFF48454e),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Image(
+                    painter = painterResource(R.drawable.ic_grain),
+                    contentDescription = stringResource(R.string.grain),
+                )
+                Text(
+                    text = topic.count.toString(),
+                    color = Color(0xFF48454e),
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = modifier.padding(8.dp, 0.dp, 0.dp, 0.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun GridAppItemPreview() {
+    GridTheme {
+        Row {
+            GridAppItem(topic = Topic(R.string.architecture, 58, R.drawable.architecture))
+            GridAppItem(topic = Topic(R.string.crafts, 121, R.drawable.crafts))
+        }
+    }
+}

--- a/app/src/main/java/com/example/grid/MainActivity.kt
+++ b/app/src/main/java/com/example/grid/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -69,7 +70,7 @@ fun GridApp(modifier: Modifier = Modifier) {
 fun GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier
-            .padding(8.dp)
+            .padding(dimensionResource(R.dimen.padding_small))
             .height(68.dp)
             .clip(shape = RoundedCornerShape(20.dp))
             .background(MaterialTheme.colorScheme.secondaryContainer)
@@ -82,10 +83,16 @@ fun GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
                 painter = painterResource(topic.icon),
                 contentDescription = stringResource(topic.name)
             )
-            Column(modifier = Modifier.padding(16.dp, 0.dp, 0.dp, 0.dp)) {
+            Column(
+                modifier = Modifier.padding(start = dimensionResource(R.dimen.padding_medium))
+            ) {
                 Text(
                     text = stringResource(topic.name),
-                    modifier = modifier.padding(0.dp, 16.dp, 16.dp, 8.dp),
+                    modifier = modifier.padding(
+                        top = dimensionResource(R.dimen.padding_medium),
+                        end = dimensionResource(R.dimen.padding_medium),
+                        bottom = dimensionResource(R.dimen.padding_small)
+                    ),
                     color = Color(0xFF48454e),
                     style = MaterialTheme.typography.bodyMedium
                 )
@@ -98,7 +105,7 @@ fun GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
                         text = topic.count.toString(),
                         color = Color(0xFF48454e),
                         style = MaterialTheme.typography.labelMedium,
-                        modifier = modifier.padding(8.dp, 0.dp, 0.dp, 0.dp)
+                        modifier = modifier.padding(start = dimensionResource(R.dimen.padding_small))
                     )
                 }
             }

--- a/app/src/main/java/com/example/grid/MainActivity.kt
+++ b/app/src/main/java/com/example/grid/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
@@ -77,8 +77,8 @@ fun GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
         Row {
             Image(
                 modifier = modifier
-                    .fillMaxHeight()
-                    .width(68.dp),
+                    .width(68.dp)
+                    .aspectRatio(1f),
                 painter = painterResource(topic.icon),
                 contentDescription = stringResource(topic.name)
             )

--- a/app/src/main/java/com/example/grid/MainActivity.kt
+++ b/app/src/main/java/com/example/grid/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -52,7 +53,7 @@ class MainActivity : ComponentActivity() {
 fun GridApp(modifier: Modifier = Modifier) {
     val window = (LocalView.current.context as Activity).window
     window.statusBarColor = MaterialTheme.colorScheme.primary.toArgb()
-    
+
     LazyVerticalGrid(
         modifier = modifier.safeDrawingPadding(),
         columns = GridCells.FixedSize(200.dp),
@@ -66,38 +67,40 @@ fun GridApp(modifier: Modifier = Modifier) {
 
 @Composable
 fun GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
-    Row(
+    Card(
         modifier = modifier
             .padding(8.dp)
             .height(68.dp)
             .clip(shape = RoundedCornerShape(20.dp))
             .background(MaterialTheme.colorScheme.secondaryContainer)
     ) {
-        Image(
-            modifier = modifier
-                .fillMaxHeight()
-                .width(68.dp),
-            painter = painterResource(topic.icon),
-            contentDescription = stringResource(topic.name)
-        )
-        Column(modifier = Modifier.padding(16.dp, 0.dp, 0.dp, 0.dp)) {
-            Text(
-                text = stringResource(topic.name),
-                modifier = modifier.padding(0.dp, 16.dp, 16.dp, 8.dp),
-                color = Color(0xFF48454e),
-                style = MaterialTheme.typography.bodyMedium
+        Row {
+            Image(
+                modifier = modifier
+                    .fillMaxHeight()
+                    .width(68.dp),
+                painter = painterResource(topic.icon),
+                contentDescription = stringResource(topic.name)
             )
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Image(
-                    painter = painterResource(R.drawable.ic_grain),
-                    contentDescription = stringResource(R.string.grain),
-                )
+            Column(modifier = Modifier.padding(16.dp, 0.dp, 0.dp, 0.dp)) {
                 Text(
-                    text = topic.count.toString(),
+                    text = stringResource(topic.name),
+                    modifier = modifier.padding(0.dp, 16.dp, 16.dp, 8.dp),
                     color = Color(0xFF48454e),
-                    style = MaterialTheme.typography.labelMedium,
-                    modifier = modifier.padding(8.dp, 0.dp, 0.dp, 0.dp)
+                    style = MaterialTheme.typography.bodyMedium
                 )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Image(
+                        painter = painterResource(R.drawable.ic_grain),
+                        contentDescription = stringResource(R.string.grain),
+                    )
+                    Text(
+                        text = topic.count.toString(),
+                        color = Color(0xFF48454e),
+                        style = MaterialTheme.typography.labelMedium,
+                        modifier = modifier.padding(8.dp, 0.dp, 0.dp, 0.dp)
+                    )
+                }
             }
         }
     }
@@ -107,9 +110,6 @@ fun GridAppItem(topic: Topic, modifier: Modifier = Modifier) {
 @Preview
 fun GridAppItemPreview() {
     GridTheme {
-        Row {
-            GridAppItem(topic = Topic(R.string.architecture, 58, R.drawable.architecture))
-            GridAppItem(topic = Topic(R.string.crafts, 121, R.drawable.crafts))
-        }
+        GridAppItem(topic = Topic(R.string.architecture, 58, R.drawable.architecture))
     }
 }

--- a/app/src/main/java/com/example/grid/data/Datasource.kt
+++ b/app/src/main/java/com/example/grid/data/Datasource.kt
@@ -1,0 +1,22 @@
+package com.example.grid.data
+
+import com.example.grid.R
+
+object Datasource {
+    val topics = listOf(
+        Topic(R.string.architecture, 58, R.drawable.architecture),
+        Topic(R.string.crafts, 121, R.drawable.crafts),
+        Topic(R.string.business, 78, R.drawable.business),
+        Topic(R.string.culinary, 118, R.drawable.culinary),
+        Topic(R.string.design, 423, R.drawable.design),
+        Topic(R.string.fashion, 92, R.drawable.fashion),
+        Topic(R.string.film, 165, R.drawable.film),
+        Topic(R.string.gaming, 164, R.drawable.gaming),
+        Topic(R.string.drawing, 326, R.drawable.drawing),
+        Topic(R.string.lifestyle, 305, R.drawable.lifestyle),
+        Topic(R.string.music, 212, R.drawable.music),
+        Topic(R.string.painting, 172, R.drawable.painting),
+        Topic(R.string.photography, 321, R.drawable.photography),
+        Topic(R.string.tech, 118, R.drawable.tech)
+    )
+}

--- a/app/src/main/java/com/example/grid/data/Topic.kt
+++ b/app/src/main/java/com/example/grid/data/Topic.kt
@@ -1,0 +1,10 @@
+package com.example.grid.data
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+
+data class Topic(
+    @StringRes val name: Int,
+    val count: Int,
+    @DrawableRes val icon: Int
+)

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="padding_medium">16dp</dimen>
+    <dimen name="padding_small">8dp</dimen>
+</resources>


### PR DESCRIPTION
From this [course](https://developer.android.com/codelabs/basic-android-kotlin-compose-practice-grid?continue=https%3A%2F%2Fdeveloper.android.com%2Fcourses%2Fpathways%2Fandroid-basics-compose-unit-3-pathway-2%23codelab-https%3A%2F%2Fdeveloper.android.com%2Fcodelabs%2Fbasic-android-kotlin-compose-practice-grid#0)

## What you'll build
In these practice problems, you will build out the Courses app from scratch. The Courses app displays a list of course topics.

The practice problems are split into sections, where you will build:

A course topic data class:
The topic data will have an image, a name, and the number of associated courses in that topic.

A composable to represent a course topic grid item:
Each topic item will display the image, the name, the number of associated courses, and a decorative icon.

A composable to display a grid of those course topic items.

The app look like this

![Capturedecran2024-11-08at16 05 47-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4871ca39-dff7-4466-9155-101cabc77654)
